### PR TITLE
adds support for RM650i

### DIFF
--- a/corsairmi.c
+++ b/corsairmi.c
@@ -65,8 +65,10 @@
 #include <linux/hidraw.h>
 
 static const uint16_t products[] = {
+	0x1c0a, /* RM650i */
 	0x1c0b, /* RM750i */
 	0x1c0c, /* RM850i */
+	/* 0x1c0d for RM1000i? */
 };
 
 static void dump(const uint8_t *buf, size_t size)


### PR DESCRIPTION
`0x1c0a` adds support for RM650i, looking at the product line, it seems the only model missing is RM1000i which is likely to be `0x1c0d`