### PR TITLE
add support for RM1000i

### DIFF
--- a/corsairmi.c
+++ b/corsairmi.c
@@ -68,7 +68,7 @@ static const uint16_t products[] = {
 	0x1c0a, /* RM650i */
 	0x1c0b, /* RM750i */
 	0x1c0c, /* RM850i */
-	/* 0x1c0d for RM1000i? */
+	0x1c0d, /* RM1000i */
 	0x1c04, /* HX650i */
 	0x1c05, /* HX750i */
 	0x1c06, /* HX850i */


### PR DESCRIPTION
Someone on the unRAID forums [has confirmed](https://forums.unraid.net/topic/70429-plugin-corsair-psu-statistics/?tab=comments#comment-677853) the device ID for Corsair RM1000i.