### PR TITLE
[FEATURE] Added support for HX1000i (2nd gen).

### DIFF
--- a/corsairmi.c
+++ b/corsairmi.c
@@ -74,6 +74,7 @@ static const uint16_t products[] = {
 	0x1c06, /* HX850i */
 	0x1c07, /* HX1000i */
 	0x1c08, /* HX1200i */
+	0x1c1e, /* HX1000i (2nd gen) */
 };
 
 static void dump(const uint8_t *buf, size_t size)


### PR DESCRIPTION
Corsair now sells a new version of the HX1000i with PID 0x1c1e. I have tested that it works as expected. See output below:

$ sudo ./corsairmi 
name:           'CORSAIR HX1000i PSU'
vendor:         'CORSAIR HX1000i PSU'
product:        'CORSAIR HX1000i PSU'
powered:        15561210 (180d. 2h)
uptime:         2010 (0d. 0h)
temp1:           45.2
temp2:           48.5
fan rpm:          0.0
supply volts:   115.0
total watts:     86.0
output0 volts:   12.1
output0 amps:     5.2
output0 watts:   66.0
output1 volts:    5.1
output1 amps:     3.5
output1 watts:   17.5
output2 volts:    3.3
output2 amps:     2.2
output2 watts:    7.0
