### PR TITLE
Add github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build and Upload Binary
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up build environment
+        run: sudo apt-get update && sudo apt-get install -y build-essential
+
+      - name: Build the project
+        run: make
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: corsairmi-binary
+          path: ./corsairmi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up build environment
-        run: sudo apt-get update && sudo apt-get install -y build-essential
-
       - name: Build the project
         run: make
 


### PR DESCRIPTION
Hello! I was interested in this project to montor my HX1000i and it works great, thanks very much

This PR adds a GitHub build for this. 

If you're interested I'd love to get this merged upstream.

You can see the successful build on my fork here, including the download working: https://github.com/Rooster212/corsairmi/actions/runs/13294209388

I tested it on my server from this build (I just downloaded it on my workstation and `scp`d it over to the box, made executable with `chmod +x corsairmi` then ran using `./corsairmi`.)

Output working:
<img width="396" alt="Screenshot 2025-02-12 at 20 38 47" src="https://github.com/user-attachments/assets/bf2a1ad0-9416-4ad6-8327-5968edea5f2f" />
